### PR TITLE
Add general resource-specific CORS

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,15 +1,9 @@
 from flask import Flask, request, Response, abort, jsonify
-from flask_cors import cross_origin
-
+from flask_cors import CORS
 from question import *
 
 app = Flask(__name__)
-
-# TODO: not hardcode this (issue #23).
-ALLOWED_ORIGINS = [
-    "http://127.0.0.1:5000",
-    "http://localhost:5000"
-]
+cors = CORS(app, resources={r"/api/v1/*": {"origins": "*"}})
 
 @app.route('/js/crowd-captcha.js')
 def js():
@@ -36,7 +30,6 @@ def js():
 
 
 @app.route('/api/v1/tag', methods=["POST"])
-@cross_origin(origins=ALLOWED_ORIGINS)
 def tag():
     """
     Takes


### PR DESCRIPTION
I think it makes more sense to have everything under /api/v1
be open to cross-origin ajax.
This also solves issue #23.

Code is taken from Flask's [documentation](https://flask-cors.readthedocs.io/en/latest/)